### PR TITLE
required-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
         env:
           STACK_YAML: ${{ matrix.stack-yaml }}
 
+  required-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: freckle/await-statuses-action@v1
+        with:
+          statuses: |
+            test (stack.yaml)
+            test (stack-lts-20.26.yaml)
+            test (stack-lts-21.25.yaml)
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The plan is to use `required-tests` as the config for `required_status_check_contexts` in [GHVM](https://github.com/freckle/github-vending-machine/blob/main/repositories/yield.yaml) so that the ghvm repo doesn't have to keep an up-to-date list of stackage resolvers for every Haskell library; that responsibility is shifted into the individual project repos.