### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": false,
   "nix": {
     "enabled": true
   }


### PR DESCRIPTION
Disables the Renovate dependency dashboard issue by setting `dependencyDashboard: false`

I don't know what that is, but it looks stupid.

Closes #13
